### PR TITLE
Bugfix: wrapped setDateSearchQuery within a useEffect

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -36,21 +36,10 @@ export const StyledCalendar = styled.div`
     flex-direction: column;
 `;
 
-const thisWeekdata2: DateProps[] = [
-    {date: 26, month: 'June', day: 'Monday', year: 2023},
-    {date: 27, month: 'June', day: 'Tuesday', year: 2023},
-    {date: 28, month: 'June', day: 'Wednesday', year: 2023},
-    {date: 29, month: 'June', day: 'Thursday', year: 2023},
-    {date: 30, month: 'June', day: 'Friday', year: 2023},
-    {date: 1, month: 'July', day: 'Saturday', year: 2023},
-    {date: 2, month: 'July', day: 'Sunday', year: 2023},
-]
-
-
 export const BaseCalendar: FC<ViewProps> = ({times})=> {
     const thisWeekdata = useContext(WeekContext)
 
-    
+
     const doubleClickHandler = (event) => {
         if (event.detail == 2) {
             console.log('create new event here')

--- a/src/components/Calendar/DateHeader.tsx
+++ b/src/components/Calendar/DateHeader.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { Paragraph, Heading2 } from '../common/Text'
 import { CommonStylingProps, DateProps2 } from '../types';
 import { dayAbbreviations, monthAbbreviations, dayMappingFromIndex, monthMappingFromIndex  } from '../../db/Mapping';
-import { TodayContext, ViewSizeContext } from '../../context/Context';
+import { SelectDateContext, TodayContext, ViewSizeContext } from '../../context/Context';
 import { generateDateId } from '../../utils/DateUtils';
 import { calcIndividualColWidth } from '../../utils';
 
@@ -61,6 +61,7 @@ export const DateHeader = (props: {thisWeek: Date[]} ) => {
 export const DHCell: FC<DateProps2> = ({date}) => {
     const todayDate = useContext(TodayContext)
     const viewSize = useContext(ViewSizeContext)
+    const selectDate = useContext(SelectDateContext)
 
     const dateNumber = date.getDate()
     const day = dayMappingFromIndex[date.getDay()]
@@ -71,6 +72,10 @@ export const DHCell: FC<DateProps2> = ({date}) => {
         dayHeading = (
             <SelectedBubble><Heading2>{dateNumber}</Heading2></SelectedBubble>
         )
+    } else if (dateNumber === selectDate.getDate()) {
+        dayHeading = (
+            <SelectedBubble bgcolor={'var(--yellow)'}><Heading2>{dateNumber}</Heading2></SelectedBubble>
+        ) 
     }
 
     return (

--- a/src/context/Context.tsx
+++ b/src/context/Context.tsx
@@ -11,3 +11,5 @@ export const ViewSizeContext = createContext(settings.view_size)
 export const WeekContext = createContext(thisWeek(new Date(), settings.view_size))
 
 export const TodayContext = createContext(new Date())
+
+export const SelectDateContext = createContext(new Date())

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -1,10 +1,10 @@
-import React, {useState} from 'react'
+import React, {useState, useEffect} from 'react'
 import { Sidebar } from '../components/Sidebar/Sidebar'
 import { BaseCalendar } from '../components/Calendar/Calendar'
 import { NavWrapper, NavButton, NavMapping } from '../components/Navbar/Navbar'
 
 import { ViewProps } from '../components/types'
-import { WeekContext, TodayContext, ViewSizeContext } from '../context/Context'
+import { WeekContext, TodayContext, ViewSizeContext, SelectDateContext } from '../context/Context'
 import { thisWeek } from '../utils/DateUtils'
 
 import DatePicker from "react-widgets/DatePicker";
@@ -18,41 +18,49 @@ const CalendarViewSettings: ViewProps = {
 
 export const View = () => {
   const [viewSize, setViewSize] = useState(settings.view_size)
-  const [dateSearchQuery, setDateSearchQuery] = useState(thisWeek(new Date(), viewSize))
   const [todayDate, setTodayDate] = useState(new Date())
+  const [selectedDate, setSelectedDate] = useState(todayDate)
+  const [dateSearchQuery, setDateSearchQuery] = useState(thisWeek(selectedDate, viewSize))
 
     
   const updateInputValue = (date: Date) => {
-      setDateSearchQuery(thisWeek(date, viewSize))
+      setSelectedDate(date)
   }
+
+  useEffect(() => {
+    console.log(selectedDate)
+    setDateSearchQuery(thisWeek(selectedDate, viewSize))
+  }, [selectedDate])
 
   return (
     <ViewSizeContext.Provider value={viewSize}>
       <WeekContext.Provider value={dateSearchQuery}>
         <TodayContext.Provider value={todayDate}>
-          <NavWrapper>
-              <NavButton navigation = {NavMapping['new']}/>
-              <div>
-                <DatePicker
-                    defaultValue={new Date()}
-                    valueFormat={{ dateStyle: "medium" }}
-                    onChange={(value: Date) => updateInputValue(value) }
-                />
-              </div>
-              <div>
-                  <NavButton navigation = {NavMapping['calendar']}/>
-                  <NavButton navigation = {NavMapping['settings']}/>
-                  <NavButton navigation = {NavMapping['test']}/>
-              </div>
-          </NavWrapper>
-          <div className="flex flex-row w-screen h-screen">
-              {/* <Sidebar /> */}
-              <Calendar 
-                defaultValue={new Date()}
-                onChange={updateInputValue}
-                />
-              <BaseCalendar times={CalendarViewSettings['times']} />
-          </div>
+          <SelectDateContext.Provider value={selectedDate}>
+            <NavWrapper>
+                <NavButton navigation = {NavMapping['new']}/>
+                <div>
+                  <DatePicker
+                      defaultValue={todayDate}
+                      valueFormat={{ dateStyle: "medium" }}
+                      onChange={(value: Date) => updateInputValue(value) }
+                  />
+                </div>
+                <div>
+                    <NavButton navigation = {NavMapping['calendar']}/>
+                    <NavButton navigation = {NavMapping['settings']}/>
+                    <NavButton navigation = {NavMapping['test']}/>
+                </div>
+            </NavWrapper>
+            <div className="flex flex-row w-screen h-screen">
+                {/* <Sidebar /> */}
+                <Calendar 
+                  defaultValue={todayDate}
+                  onChange={updateInputValue}
+                  />
+                <BaseCalendar times={CalendarViewSettings['times']} />
+            </div>
+          </SelectDateContext.Provider>
         </TodayContext.Provider>
       </WeekContext.Provider>
     </ViewSizeContext.Provider>


### PR DESCRIPTION
Why?
> now whenever our selectedDate changes - we will re-render the calendar without fail
> previously we were experiencing a 70% success rate for re-rendering the calendar.

What?
(1) removed old data code that became deprecated - used for original build of some components (2) created new SelectDateContext this allows us to specifically target certain dateSearchQuery

Up Next:
BugFix: currently our logic for handling 'todaysDate' is depedent on purely date matching, we need all date variables to match: issue: every single month there is a selected 'today'sdate' based on the date of the month